### PR TITLE
shift-invert method to improve eigsh convergence

### DIFF
--- a/qmsolve/hamiltonian.py
+++ b/qmsolve/hamiltonian.py
@@ -38,7 +38,7 @@ class Hamiltonian:
         H = self.T + self.V
         print ("Computing...")
         t0 = time.time()
-        eigenvalues, eigenvectors = eigsh(H, k = max_states, which='SA')
+        eigenvalues, eigenvectors = eigsh(H, k = max_states, which='LM', sigma=0)
 
         """
         the result of this method depends of the particle system. For example if the systems are two fermions, this method


### PR DESCRIPTION
Following guidance here: https://docs.scipy.org/doc/scipy/reference/tutorial/arpack.html#shift-invert-mode. Simple tests show dramatic speedup in eigensolver. 