### PR TITLE
Feature lobpcg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/examples/lobpcg_vs_eigsh.py
+++ b/examples/lobpcg_vs_eigsh.py
@@ -1,0 +1,50 @@
+import numpy as np
+from qmsolve import Hamiltonian, SingleParticle, init_visualization
+
+
+#interaction potential
+def harmonic_oscillator(particle):
+
+	kx, ky, kz = [2]*3 # measured in eV / (Å**2)
+	return 0.5 * kx * particle.x**2 +\
+		   0.5 * ky * particle.y**2 +\
+		   0.5 * kz * particle.z**2
+
+
+if __name__=='__main__':
+
+	# simulation params
+	grid_size=30
+	extent=10
+	num_states=10
+
+	# set up the system
+	H = Hamiltonian(particles = SingleParticle(),
+					potential = harmonic_oscillator,
+					spatial_ndim = 3, N = grid_size, extent = extent)
+
+
+	# solve with eigsh
+	print('-'*30)
+	print("Solving with scipy.sparse.linalg.eigsh")
+	eig_eigsh = H.solve(max_states = num_states).energies
+	print("Eigenvalues (eigsh) :", eig_eigsh)
+
+	# solve with lobpcg
+	print('-'*30)
+	print("Solving with scipy.sparse.linalg.lobpcg")
+	eig_lobpcg = H.solve(max_states = num_states, method='lobpcg').energies
+	print("Eigenvalues (lobpcg):", eig_lobpcg)
+
+	# try to solve with some other method
+	print('-'*30)
+	print("Solving with foo")
+	try:
+		eig_foo = H.solve(max_states= num_states, method='foo')
+	except NotImplementedError as e:
+		print(e)
+
+	# compare computed eigenvalues
+	print('-'*30)
+	print("Diff. over mean:", 2*np.abs(eig_eigsh-eig_lobpcg)/(eig_eigsh+eig_lobpcg))
+

--- a/qmsolve/hamiltonian.py
+++ b/qmsolve/hamiltonian.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse.linalg import eigsh
+from scipy.sparse.linalg import eigsh, lobpcg, LinearOperator
 from scipy.sparse import diags
 import time
 
@@ -30,16 +30,47 @@ class Hamiltonian:
         V = diags([V], [0])
         return V
 
-    def solve(self, max_states):
+    def solve(self, max_states: int, method: str = 'eigsh'):
+        """
+        Diagonalize the hamiltonian and retrieve the lowest-energy eigenstates
+        Args:
+            max_states: the number of states to retreive
+            method: the solver method. Currently, 'eigsh' and 'lobpcg' are implemented. Note: 'lobpcg' is potentially
+            much faster than 'eigsh' but can fail catastrophically for some systems. Use 'lobpcg' with care.
+
+        Returns:
+
+        """
+        implemented_solvers = ('eigsh', 'lobpcg')
+
         H = self.T + self.V
         print("Computing...")
         t0 = time.time()
-        eigenvalues, eigenvectors = eigsh(H, k=max_states, which='LM', sigma=0)
 
-        """
-        the result of this method depends of the particle system. For example if the systems are two fermions, this method
-        makes the eigenstates antisymmetric
-        """
+        if method == 'eigsh':
+            # Note: uses shift-invert trick for stability finding low-lying states
+            # Ref: https://docs.scipy.org/doc/scipy/reference/tutorial/arpack.html#shift-invert-mode
+            eigenvalues, eigenvectors = eigsh(H, k=max_states, which='LM', sigma=0)
+        elif method == 'lobpcg':
+            # preconditioning matrix should approximate the inverse of the hamiltonian
+            # we naively construct this by taking the inverse of diagonal elements
+            # and setting all others to zero. This is called the Jacobi or diagonal preconditioner.
+            A = diags([1 / H.diagonal()], [0]).tocsc()
+            precond = lambda x: A @ x
+            M = LinearOperator(H.shape, matvec=precond, matmat=precond)
+
+            # guess for eigenvectors is computed from random numbers
+            # TODO: a better guess would be to use the eigenstates of a reference system like a square well
+            X_approx = np.random.rand(H.shape[0], max_states)
+
+            sol = lobpcg(H, X_approx, largest=False, M=M, tol=1e-15)
+            eigenvalues, eigenvectors = sol[0], sol[1]
+        else:
+            raise NotImplementedError(
+                f"{method} solver has not been implemented. Use one of {implemented_solvers}")
+
+        """the result of this method depends of the particle system. For example if the systems are two fermions, 
+        this method makes the eigenstates antisymmetric """
         self.eigenstates = self.particle_system.get_eigenstates(self, max_states, eigenvalues, eigenvectors)
 
         print("Took", time.time() - t0)

--- a/qmsolve/hamiltonian.py
+++ b/qmsolve/hamiltonian.py
@@ -5,19 +5,18 @@ import time
 
 
 class Hamiltonian:
-    def __init__(self,particles, potential, N, extent, spatial_ndim):
+    def __init__(self, particles, potential, N, extent, spatial_ndim):
         """
         N: number of grid points
         extent: spacial extent, measured in angstroms
         """
 
-        
         self.N = N
         self.extent = extent
-        self.dx = extent/N
+        self.dx = extent / N
         self.particle_system = particles
-        self.spatial_ndim = spatial_ndim 
-        self.ndim = 0 # total number of observables 
+        self.spatial_ndim = spatial_ndim
+        self.ndim = 0  # total number of observables
 
         self.particle_system.get_observables(self)
         self.T = self.particle_system.get_kinetic_matrix(self)
@@ -25,21 +24,17 @@ class Hamiltonian:
         self.potential = potential
         self.V = self.get_potential_matrix()
 
-        
     def get_potential_matrix(self):
-
         V = self.potential(self.particle_system)
-        V = V.reshape(self.N**self.ndim)
+        V = V.reshape(self.N ** self.ndim)
         V = diags([V], [0])
         return V
 
-
     def solve(self, max_states):
-
         H = self.T + self.V
-        print ("Computing...")
+        print("Computing...")
         t0 = time.time()
-        eigenvalues, eigenvectors = eigsh(H, k = max_states, which='LM', sigma=0)
+        eigenvalues, eigenvectors = eigsh(H, k=max_states, which='LM', sigma=0)
 
         """
         the result of this method depends of the particle system. For example if the systems are two fermions, this method
@@ -47,8 +42,5 @@ class Hamiltonian:
         """
         self.eigenstates = self.particle_system.get_eigenstates(self, max_states, eigenvalues, eigenvectors)
 
-        print ("Took", time.time() - t0)
+        print("Took", time.time() - t0)
         return self.eigenstates
-
-
-

--- a/qmsolve/particle_system/particle_system.py
+++ b/qmsolve/particle_system/particle_system.py
@@ -1,7 +1,7 @@
-from abc import abstractmethod 
+from abc import ABC, abstractmethod
 
 
-class ParticleSystem:
+class ParticleSystem(ABC):
     @abstractmethod
     def __init__(self):
         pass

--- a/qmsolve/particle_system/single_particle.py
+++ b/qmsolve/particle_system/single_particle.py
@@ -63,6 +63,8 @@ class SingleParticle(ParticleSystem):
             type = "SingleParticle1D"
         elif H.spatial_ndim == 2:
             type = "SingleParticle2D"
+        elif H.spatial_ndim == 3:
+            type = "SingleParticle3D"
 
         eigenstates = Eigenstates(energies, eigenstates_array, H, type)
         return eigenstates


### PR DESCRIPTION
This branch implements an alternative eigensolver routine that has much quicker convergence in some circumstances. The new solver is based on [scipy.sparse.linalg.lobpcg](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.lobpcg.html). By default the code behaves as before and uses the eigsh solver. To use the new method pass `method="lobpcg"` to `Hamiltonian.solve`. 

Unfortunately, `lobpcg` is not nearly as reliable as `eigsh`. In some cases, `lobpcg` is very slow and produces very wrong results. I have seen better convergence in situations that do not require large grid size. I have only tested on harmonic oscillator. I see no benefit for 1 or 2 dimensions, and a large benefit in 3 dimensions. I have written a script to demonstrate this as discussed below. Further tests are needed to determine the stability in a wider range situations.  

Though not strictly required, the implementation benefits from providing a preconditioning operator that approximates the inverse of the matrix to be diagonalized (the hamiltonian in this case). The actual inverse cannot be efficiently computed. The current code uses the "Jacobi" or "diagonal" conditioning matrix which is a matrix of zeros except along the diagonal. On the diagonal, the values are simply 1/diagonal of the original hamiltonian values. 

To demonstrate the usage,  I have created a new example script in a new examples/ folder (btw, perhaps we should put all examples here; top level is looking very crowded :). The example script solves for the eigenstates of a single particle in a 3d isotropic HO. The lobpcg solver is ~40 times faster in my test with relative errors <2% for the first 5 eigenvalues. The 10th eigenvalue has 25%. Here is an example output from running the script: 

```{shell}
------------------------------
Solving with scipy.sparse.linalg.eigsh
Computing...
Took 36.023282051086426
Eigenvalues (eigsh) : [ 6.03533971 10.04416034 10.04416034 10.04416034 14.0257434  14.0257434
 14.0257434  14.05298098 14.05298098 14.05298098]
------------------------------
Solving with scipy.sparse.linalg.lobpcg
Computing...
Took 0.9391400814056396
Eigenvalues (lobpcg): [ 6.03600915 10.05316063 10.0997381  10.24087437 14.05243788 14.2446791
 14.31203711 14.66924361 15.23159918 18.16693888]
------------------------------
Solving with foo
Computing...
foo solver has not been implemented. Use one of ('eigsh', 'lobpcg')
------------------------------
Diff. over mean: [1.10914213e-04 8.95670917e-04 5.51807386e-03 1.93949903e-02
 1.90143947e-03 1.54886751e-02 2.02057964e-02 4.29119016e-02
 8.04941167e-02 2.55367358e-01]

Process finished with exit code 0
```